### PR TITLE
0.4.1

### DIFF
--- a/the_blocker_mod/events/TBM_02_events.txt
+++ b/the_blocker_mod/events/TBM_02_events.txt
@@ -1261,7 +1261,7 @@ planet_event = {
 	immediate = {
 		
 		export_trigger_value_to_variable = {
-			trigger = num_ssigned_jobs
+			trigger = num_assigned_jobs
 			parameters = {
 				job = miner
 			}


### PR DESCRIPTION
Hotfix to correct crash caused by typo in export_trigger_value_to_variable, again.